### PR TITLE
Draw the weight overlay at the entity center

### DIFF
--- a/lua/weapons/gmod_tool/stools/weight_improved.lua
+++ b/lua/weapons/gmod_tool/stools/weight_improved.lua
@@ -313,7 +313,7 @@ if ( CLIENT ) then
 		local modWeightStr = string.Comma( modWeight or "N/A" )
 		
 		-- gets the vector position of the center of the entity and translates it to x/y coordinates on the client's screen
-		local pos = (ent:GetPos() + ent:OBBCenter()):ToScreen()
+		local pos = ent:LocalToWorld(ent:OBBCenter()):ToScreen()
 		local x, y = pos.x, pos.y
 		
 		local useLegacy = shouldUseLegacyTooltip()

--- a/lua/weapons/gmod_tool/stools/weight_improved.lua
+++ b/lua/weapons/gmod_tool/stools/weight_improved.lua
@@ -313,7 +313,7 @@ if ( CLIENT ) then
 		local modWeightStr = string.Comma( modWeight or "N/A" )
 		
 		-- gets the vector position of the center of the entity and translates it to x/y coordinates on the client's screen
-		local pos = ent:LocalToWorld(ent:OBBCenter()):ToScreen()
+		local pos = tr.HitPos:ToScreen()
 		local x, y = pos.x, pos.y
 		
 		local useLegacy = shouldUseLegacyTooltip()


### PR DESCRIPTION
Center drawing overlay relative to the OBB center of the prop that works even for those with misaligned positions and long local OBB.